### PR TITLE
When setting the path option to empty string the path is defaulted to st...

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function(options) {
     fileArr: [
       {'@identifier':  'resource_1'},
       {'@type': 'webcontent'},
-      {'@href': options.path+'/'+options.launchPage}
+      {'@href': (options.path ? options.path + "/" : "") + options.launchPage}
     ]
   };
 
@@ -54,7 +54,7 @@ module.exports = function(options) {
   var addFile = function(file, lastmode, cb) {
     var fObj = {
       file: {
-        '@href':options.path+'/'+file.relative
+        '@href':(options.path ? options.path + "/" : "") + file.relative
       }
     };
     xmlTokens.fileArr.push(fObj);


### PR DESCRIPTION
...art with /, this

makes the paths faulty when testing in scormcloud.

Added functionality to the path option to remove the / when path is set to empty.