### PR TITLE
Added edition option for 2004 version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ build/Release
 # Deployed apps should consider commenting this line out:
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
+.idea/

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Possible values: `2004||1.2`
 
 This is used to define which version of SCORM will be applied to the manifest.
 
+#### options.edition (only for version 2004):
+Type: `String`
+Default value: `'3rd'`
+Possible values: `1st||2nd||3rd||4th`
+
+This is used to define which edition of SCORM 2004 will be applied to the manifest.
+
 #### options.courseId
 Type: `String`
 Default value: `'CourseID'`

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = function(options) {
 
   _.extend({
     version: '2004',
+    edition: '3rd',
     courseId: 'CourseID',
     SCOtitle: 'SCO Title',
     moduleTitle: 'Module Title',
@@ -36,13 +37,14 @@ module.exports = function(options) {
   };
 
   var v = options.version.toLowerCase();
+  var ed = options.edition || '3rd';
 
   if (v==='1.2') {
     xmlTokens.versionString = '1.2';
     xmlTokens.scormType = 'adlcp:scormtype';
 
   } else if (v.indexOf('2004')===0) {
-    xmlTokens.versionString = '2004 3rd Edition';
+    xmlTokens.versionString = '2004 '+ed+' Edition';
     xmlTokens.scormType = 'adlcp:scormType';
   }
 


### PR DESCRIPTION
I've added an option to set edition for SCORM 2004 manifests. There is no much difference in manifests, but some LMS requires 4th edition to be set.